### PR TITLE
add gochan-empty? procedure

### DIFF
--- a/gochan-module.scm
+++ b/gochan-module.scm
@@ -8,6 +8,8 @@
 
                 gochan-select*
                 gochan-select
+                
+                gochan-empty?
 
                 gochan-after
                 gochan-tick

--- a/gochan.scm
+++ b/gochan.scm
@@ -582,6 +582,9 @@
          (gochan-select* (gochan-select-alist form ...))
        (meta msg ok)))))
 
+(define (gochan-empty? chan)
+  (queue-empty? (gochan-buffer chan)))
+
 (define-record-printer gochan
   (lambda (x p)
     (display "#<gochan " p)


### PR DESCRIPTION
I have a case where I want to prioritise incoming messages over other processing. I could do a non-blocking gochan-select but that would mean writing out the select clauses twice (once non-blocking to prioritise incoming messages, then again after processing to put the thread to sleep while it waits for the next message). By calling gochan-empty? I can decide whether to run my single gochan-select statement upfront or not.

I'm open to other suggestions on how to approach this use case.